### PR TITLE
[174725913] Allow authorized user to get organization, given a slug

### DIFF
--- a/src/clj/chronograph/db/organization.clj
+++ b/src/clj/chronograph/db/organization.clj
@@ -18,18 +18,11 @@
                   db/sql-opts))))
 
 
-(defn find-one
-  "Fetch the exact match organization for the given slug and user IFF
-  the user belongs to the organization's ACL. Else return nil."
-  ([slug user-id]
-   (find-one db/datasource slug user-id))
-  ([tx slug user-id]
-   (jdbc/execute-one! tx
-                      ["SELECT organizations.*
-                        FROM organizations
-                        INNER JOIN acls ON
-                                   organizations.id = acls.organization_id
-                                   AND organizations.slug = ?
-                                   AND acls.user_id = ?"
-                       slug user-id]
-                      db/sql-opts)))
+(defn find-by-slug
+  ([slug]
+   (find-by-slug db/datasource slug))
+  ([tx slug]
+   (first (sql/find-by-keys tx
+                            :organizations
+                            {:slug slug}
+                            db/sql-opts))))

--- a/src/clj/chronograph/db/organization.clj
+++ b/src/clj/chronograph/db/organization.clj
@@ -1,7 +1,8 @@
 (ns chronograph.db.organization
   (:require [chronograph.db.core :as db]
             [next.jdbc.sql :as sql]
-            [chronograph.utils.time :as time]))
+            [chronograph.utils.time :as time]
+            [next.jdbc :as jdbc]))
 
 (defn create!
   ([organization]
@@ -15,3 +16,20 @@
                    :created-at now
                    :updated-at now}
                   db/sql-opts))))
+
+
+(defn find-one
+  "Fetch the exact match organization for the given slug and user IFF
+  the user belongs to the organization's ACL. Else return nil."
+  ([slug user-id]
+   (find-one db/datasource slug user-id))
+  ([tx slug user-id]
+   (jdbc/execute-one! tx
+                      ["SELECT organizations.*
+                        FROM organizations
+                        INNER JOIN acls ON
+                                   organizations.id = acls.organization_id
+                                   AND organizations.slug = ?
+                                   AND acls.user_id = ?"
+                       slug user-id]
+                      db/sql-opts)))

--- a/src/clj/chronograph/domain/acl.clj
+++ b/src/clj/chronograph/domain/acl.clj
@@ -1,7 +1,8 @@
 (ns chronograph.domain.acl
   (:require [chronograph.db.acl :as db-acl]
             [clojure.spec.alpha :as s]
-            [chronograph.domain.user :as user]))
+            [chronograph.domain.user :as user]
+            [chronograph.db.core :as db]))
 
 
 (def admin "admin")
@@ -12,3 +13,9 @@
 (defn admin? [user-id organization-id]
   (= admin
      (get (db-acl/find-acl user-id organization-id) :acls/role)))
+
+(defn belongs-to-org?
+  ([user-id organization-id]
+   (belongs-to-org? db/datasource user-id organization-id))
+  ([tx user-id organization-id]
+   (some? (db-acl/find-acl tx user-id organization-id))))

--- a/src/clj/chronograph/domain/organization.clj
+++ b/src/clj/chronograph/domain/organization.clj
@@ -13,4 +13,12 @@
                        :role acl/admin})
       organization)))
 
-(def find-one db-organization/find-one)
+(defn find-if-authorized
+  [slug user-id]
+  (jdbc/with-transaction [tx db/datasource]
+    (when-let [{:organizations/keys [id]
+                :as organization} (db-organization/find-by-slug tx slug)]
+      (when (acl/belongs-to-org? tx
+                                 user-id
+                                 id)
+        organization))))

--- a/src/clj/chronograph/domain/organization.clj
+++ b/src/clj/chronograph/domain/organization.clj
@@ -12,3 +12,5 @@
                        :organization-id id
                        :role acl/admin})
       organization)))
+
+(def find-one db-organization/find-one)

--- a/src/clj/chronograph/handlers/organization.clj
+++ b/src/clj/chronograph/handlers/organization.clj
@@ -26,7 +26,7 @@
   (if-not (s/valid? :organizations/slug slug)
     (response/bad-request
      {:error "Bad slug"})
-    (if-let [organization (organization/find-one slug id)]
+    (if-let [organization (organization/find-if-authorized slug id)]
       (-> organization
           response/response)
       (response/not-found

--- a/src/clj/chronograph/handlers/organization.clj
+++ b/src/clj/chronograph/handlers/organization.clj
@@ -10,7 +10,7 @@
   [{{:keys [name slug] :as body} :body
     {:keys [users/id] :as user} :user
     :as request}]
-  (if-not (s/valid? :organizations/create-params-handler body)
+  (if-not (s/valid? :organizations/create-params-un body)
     (response/bad-request
      {:error "Bad name or slug."})
     (-> (organization/create! {:organizations/name name :organizations/slug slug}

--- a/src/clj/chronograph/handlers/organization.clj
+++ b/src/clj/chronograph/handlers/organization.clj
@@ -15,4 +15,19 @@
      {:error "Bad name or slug."})
     (-> (organization/create! {:organizations/name name :organizations/slug slug}
                               id)
-        response/response )))
+        response/response)))
+
+(defn find-one
+  "Any user may query details about the requested organization, as long as they
+  belong to the organization."
+  [{{:keys [slug]} :params
+    {:users/keys [id]} :user
+    :as request}]
+  (if-not (s/valid? :organizations/slug slug)
+    (response/bad-request
+     {:error "Bad slug"})
+    (if-let [organization (organization/find-one slug id)]
+      (-> organization
+          response/response)
+      (response/not-found
+       {:error "Not found"}))))

--- a/src/clj/chronograph/server.clj
+++ b/src/clj/chronograph/server.clj
@@ -29,7 +29,9 @@
         ["api/" [["users/me" {:get (-> user/me
                                        middleware/wrap-authenticated)}]
                  ["organizations" {:post (-> organization/create
-                                             middleware/wrap-authenticated)}]]]
+                                             middleware/wrap-authenticated)
+                                   ["/" :slug] {:get (-> organization/find-one
+                                                         middleware/wrap-authenticated)}}]]]
         [true (fn [_] (-> (response/resource-response "public/index.html")
                           (response/content-type "text/html")))]]])
 

--- a/src/cljc/chronograph/specs.cljc
+++ b/src/cljc/chronograph/specs.cljc
@@ -34,7 +34,7 @@
 (s/def :organizations/id int?)
 
 (s/def :organizations/create-params (s/keys :req [:organizations/name :organizations/slug]))
-(s/def :organizations/create-params-handler (s/keys :req-un [:organizations/name :organizations/slug]))
+(s/def :organizations/create-params-un (s/keys :req-un [:organizations/name :organizations/slug]))
 (s/def :organizations/organization (s/keys :req [:organizations/id
                                                  :organizations/name
                                                  :organizations/slug]))

--- a/src/cljs/chronograph_web/config.cljs
+++ b/src/cljs/chronograph_web/config.cljs
@@ -1,0 +1,3 @@
+(ns chronograph-web.config)
+
+(goog-define request-timeout 8000)

--- a/src/cljs/chronograph_web/core.cljs
+++ b/src/cljs/chronograph_web/core.cljs
@@ -3,7 +3,9 @@
             [re-frame.core :as rf]
             [chronograph.specs]
             [chronograph-web.events.user :as user-events]
-            [chronograph-web.events.routing :as routing-events]
+            [chronograph-web.events.routing]
+            [chronograph-web.pages.create-organization.events]
+            [chronograph-web.pages.organization.events]
             [chronograph-web.routes :as routes]
             [chronograph-web.views :as views]
             [chronograph-web.effects]))

--- a/src/cljs/chronograph_web/events.cljs
+++ b/src/cljs/chronograph_web/events.cljs
@@ -1,6 +1,0 @@
-(ns chronograph-web.events
-  (:require [chronograph-web.events.user]
-            [chronograph-web.events.routing]
-
-            [chronograph-web.pages.create-organization.events]
-            [chronograph-web.pages.organization.events]))

--- a/src/cljs/chronograph_web/events.cljs
+++ b/src/cljs/chronograph_web/events.cljs
@@ -2,4 +2,5 @@
   (:require [chronograph-web.events.user]
             [chronograph-web.events.routing]
 
-            [chronograph-web.pages.create-organization.events]))
+            [chronograph-web.pages.create-organization.events]
+            [chronograph-web.pages.organization.events]))

--- a/src/cljs/chronograph_web/events/routing.cljs
+++ b/src/cljs/chronograph_web/events/routing.cljs
@@ -1,11 +1,23 @@
 (ns chronograph-web.events.routing
   (:require [re-frame.core :as rf]
-            [chronograph-web.db :as db]))
+            [chronograph-web.pages.organization.events :as org-events]))
 
-(rf/reg-event-db
-  ::set-page
-  (fn [db [_ route]]
-    (assoc db :page route)))
+
+(defn- on-navigate
+  [{:keys [handler]
+    :as route}]
+  (case handler
+    :organization-show {:http-xhrio (org-events/get-organization route)}
+    nil))
+
+
+(rf/reg-event-fx
+ ::set-page
+ (fn [db [_ route]]
+   (merge
+    (on-navigate route)
+    {:db (assoc db :page route)})))
+
 
 (rf/reg-event-fx
   ::set-token

--- a/src/cljs/chronograph_web/events/routing.cljs
+++ b/src/cljs/chronograph_web/events/routing.cljs
@@ -1,22 +1,11 @@
 (ns chronograph-web.events.routing
-  (:require [re-frame.core :as rf]
-            [chronograph-web.pages.organization.events :as org-events]))
+  (:require [re-frame.core :as rf]))
 
 
-(defn- on-navigate
-  [{:keys [handler]
-    :as route}]
-  (case handler
-    :organization-show {:http-xhrio (org-events/get-organization route)}
-    nil))
-
-
-(rf/reg-event-fx
+(rf/reg-event-db
  ::set-page
  (fn [db [_ route]]
-   (merge
-    (on-navigate route)
-    {:db (assoc db :page route)})))
+   (assoc db :page route)))
 
 
 (rf/reg-event-fx

--- a/src/cljs/chronograph_web/http.cljs
+++ b/src/cljs/chronograph_web/http.cljs
@@ -1,12 +1,13 @@
 (ns chronograph-web.http
   (:refer-clojure :exclude [get])
-  (:require [ajax.core :as ajax]))
+  (:require [ajax.core :as ajax]
+            [chronograph-web.config :as config]))
 
 (defn get
   [uri http-xhrio-map]
   (merge {:method :get
           :uri uri
-          :timeout 8000 ;; TODO: put in config?
+          :timeout config/request-timeout
           :response-format (ajax/json-response-format {:keywords? true})}
          http-xhrio-map))
 

--- a/src/cljs/chronograph_web/http.cljs
+++ b/src/cljs/chronograph_web/http.cljs
@@ -1,9 +1,19 @@
 (ns chronograph-web.http
+  (:refer-clojure :exclude [get])
   (:require [ajax.core :as ajax]))
 
-(defn post [uri m]
+(defn get
+  [uri http-xhrio-map]
+  (merge {:method :get
+          :uri uri
+          :timeout 8000 ;; TODO: put in config?
+          :response-format (ajax/json-response-format {:keywords? true})}
+         http-xhrio-map))
+
+
+(defn post [uri http-xhrio-map]
   (merge {:method :post
           :uri uri
           :format          (ajax/json-request-format)
           :response-format (ajax/json-response-format {:keywords? true})}
-         m))
+         http-xhrio-map))

--- a/src/cljs/chronograph_web/pages/landing/views.cljs
+++ b/src/cljs/chronograph_web/pages/landing/views.cljs
@@ -1,6 +1,5 @@
 (ns chronograph-web.pages.landing.views
   (:require [re-frame.core :as rf]
-            [chronograph-web.events :as events]
             [chronograph-web.subscriptions :as subs]))
 
 (defn landing-page [_]

--- a/src/cljs/chronograph_web/pages/organization/events.cljs
+++ b/src/cljs/chronograph_web/pages/organization/events.cljs
@@ -4,15 +4,15 @@
 
 
 (def ^:private get-organization-uri
-  "/api/organizations")
+  "/api/organizations/")
 
 
-(defn get-organization
-  [route]
-  (http/get (str get-organization-uri
-                 (get-in route [:route-params :slug]))
-            {:on-success [::fetch-organization-success]
-             :on-failure [::fetch-organization-fail]}))
+(rf/reg-event-fx
+ ::fetch-organization
+ (fn [_ [_ slug]]
+   {:http-xhrio (http/get (str get-organization-uri slug)
+                          {:on-success [::fetch-organization-success]
+                           :on-failure [::fetch-organization-fail]})}))
 
 
 (rf/reg-event-db

--- a/src/cljs/chronograph_web/pages/organization/events.cljs
+++ b/src/cljs/chronograph_web/pages/organization/events.cljs
@@ -10,9 +10,11 @@
 (rf/reg-event-fx
  ::fetch-organization
  (fn [_ [_ slug]]
+   ;; TODO: optimize fetch and rendering in case we already have
+   ;; data for the organization, in our db.
    {:http-xhrio (http/get (str get-organization-uri slug)
                           {:on-success [::fetch-organization-success]
-                           :on-failure [::fetch-organization-fail]})}))
+                           :on-failure [::fetch-organization-fail slug]})}))
 
 
 (rf/reg-event-db
@@ -25,5 +27,7 @@
 
 (rf/reg-event-db
  ::fetch-organization-fail
- (fn [db _]
-   db))
+ (fn [db [_ slug]]
+   (assoc-in db
+             [:organizations slug]
+             ::not-found)))

--- a/src/cljs/chronograph_web/pages/organization/events.cljs
+++ b/src/cljs/chronograph_web/pages/organization/events.cljs
@@ -1,0 +1,29 @@
+(ns chronograph-web.pages.organization.events
+  (:require [re-frame.core :as rf]
+            [chronograph-web.http :as http]))
+
+
+(def ^:private get-organization-uri
+  "/api/organizations")
+
+
+(defn get-organization
+  [route]
+  (http/get (str get-organization-uri
+                 (get-in route [:route-params :slug]))
+            {:on-success [::fetch-organization-success]
+             :on-failure [::fetch-organization-fail]}))
+
+
+(rf/reg-event-db
+ ::fetch-organization-success
+ (fn [db [_ {:keys [slug] :as organization}]]
+   (assoc-in db
+             [:organizations slug]
+             organization)))
+
+
+(rf/reg-event-db
+ ::fetch-organization-fail
+ (fn [db _]
+   db))

--- a/src/cljs/chronograph_web/pages/organization/views.cljs
+++ b/src/cljs/chronograph_web/pages/organization/views.cljs
@@ -3,9 +3,14 @@
             [chronograph-web.subscriptions :as subs]))
 
 (defn organization-page [{:keys [slug]}]
-  (if-let [{:keys [name]} @(rf/subscribe [::subs/organization slug])]
+  (if-let [{:keys [id name slug created-at updated-at]}
+           @(rf/subscribe [::subs/organization slug])]
     [:div
-     [:strong "Name"]
-     " "
-     name]
+     [:strong "Organization details: "]
+     [:ul
+      [:li "ID: " id]
+      [:li "Name: " name]
+      [:li "Slug: " slug]
+      [:li "Created at: " created-at]
+      [:li "Updated at: " updated-at]]]
     [:p "Not found"]))

--- a/src/cljs/chronograph_web/pages/organization/views.cljs
+++ b/src/cljs/chronograph_web/pages/organization/views.cljs
@@ -3,17 +3,21 @@
             [chronograph-web.subscriptions :as subs]
             [chronograph-web.pages.organization.events :as org-events]))
 
+
 (defn organization-page [{:keys [slug]}]
   (rf/dispatch [::org-events/fetch-organization slug])
   (fn [_]
-    (if-let [{:keys [id name slug created-at updated-at]}
-             @(rf/subscribe [::subs/organization slug])]
-      [:div
-       [:strong "Organization details: "]
-       [:ul
-        [:li "ID: " id]
-        [:li "Name: " name]
-        [:li "Slug: " slug]
-        [:li "Created at: " created-at]
-        [:li "Updated at: " updated-at]]]
-      [:p "Not found"])))
+    (when-let [{:keys [id name slug created-at updated-at]
+                :as organization}
+               @(rf/subscribe [::subs/organization slug])]
+      (if (= organization ::org-events/not-found)
+        [:p "Not found"]
+
+        [:div
+         [:strong "Organization details: "]
+         [:ul
+          [:li "ID: " id]
+          [:li "Name: " name]
+          [:li "Slug: " slug]
+          [:li "Created at: " created-at]
+          [:li "Updated at: " updated-at]]]))))

--- a/src/cljs/chronograph_web/pages/organization/views.cljs
+++ b/src/cljs/chronograph_web/pages/organization/views.cljs
@@ -1,16 +1,19 @@
 (ns chronograph-web.pages.organization.views
   (:require [re-frame.core :as rf]
-            [chronograph-web.subscriptions :as subs]))
+            [chronograph-web.subscriptions :as subs]
+            [chronograph-web.pages.organization.events :as org-events]))
 
 (defn organization-page [{:keys [slug]}]
-  (if-let [{:keys [id name slug created-at updated-at]}
-           @(rf/subscribe [::subs/organization slug])]
-    [:div
-     [:strong "Organization details: "]
-     [:ul
-      [:li "ID: " id]
-      [:li "Name: " name]
-      [:li "Slug: " slug]
-      [:li "Created at: " created-at]
-      [:li "Updated at: " updated-at]]]
-    [:p "Not found"]))
+  (rf/dispatch [::org-events/fetch-organization slug])
+  (fn [_]
+    (if-let [{:keys [id name slug created-at updated-at]}
+             @(rf/subscribe [::subs/organization slug])]
+      [:div
+       [:strong "Organization details: "]
+       [:ul
+        [:li "ID: " id]
+        [:li "Name: " name]
+        [:li "Slug: " slug]
+        [:li "Created at: " created-at]
+        [:li "Updated at: " updated-at]]]
+      [:p "Not found"])))

--- a/src/cljs/chronograph_web/views.cljs
+++ b/src/cljs/chronograph_web/views.cljs
@@ -1,6 +1,5 @@
 (ns chronograph-web.views
   (:require [re-frame.core :as rf]
-            [chronograph-web.events :as events]
             [chronograph-web.routes :as routes]
             [chronograph-web.subscriptions :as subs]))
 

--- a/test/clj/chronograph/domain/acl_test.clj
+++ b/test/clj/chronograph/domain/acl_test.clj
@@ -46,3 +46,27 @@
                     :organization-id organization-id
                     :role acl/admin})
       (is (acl/admin? user-id organization-id)))))
+
+(deftest belongs-to-org?-test
+  (let [user (factories/create-user)
+        organization (factories/create-organization (:users/id user))]
+
+    (testing "when a user is an admin of the organization"
+      (is (acl/belongs-to-org? (:users/id user)
+                               (:organizations/id organization))))
+
+    (testing "when a user does not exist"
+      (is (not (acl/belongs-to-org? (Long/MAX_VALUE)
+                                    (:organizations/id organization)))))
+
+    (testing "when an organization does not exist"
+      (is (not (acl/belongs-to-org? (:users/id user)
+                                    nil))))
+
+    (testing "when a user is not an 'admin' of the organization"
+      (let [member (factories/create-user)]
+        (acl/create! {:user-id (:users/id member)
+                      :organization-id (:organizations/id organization)
+                      :role acl/member})
+        (is (acl/belongs-to-org? (:users/id member)
+                                 (:organizations/id organization)))))))

--- a/test/clj/chronograph/domain/organization_test.clj
+++ b/test/clj/chronograph/domain/organization_test.clj
@@ -32,15 +32,15 @@
           {user-two :users/id} (factories/create-user)
           organization-two (factories/create-organization user-two)]
       (is (= organization-one
-             (organization/find-one (:organizations/slug organization-one)
-                                    user-one))
+             (organization/find-if-authorized (:organizations/slug organization-one)
+                                              user-one))
           "user-one can look up the organization they belong to")
-      (is (nil? (organization/find-one (:organizations/slug organization-two)
-                                       user-one))
+      (is (nil? (organization/find-if-authorized (:organizations/slug organization-two)
+                                                 user-one))
           "user-one CANNOT look up an organization they don't belong to")
-      (is (nil? (organization/find-one "this-does-not-exist"
-                                       user-one))
-          "find-one returns nil when the organization does not exist")
-      (is (nil? (organization/find-one (:organizations/slug organization-one)
-                                       (Long/MAX_VALUE)))
+      (is (nil? (organization/find-if-authorized "this-does-not-exist"
+                                                 user-one))
+          "find-if-authorized returns nil when the organization does not exist")
+      (is (nil? (organization/find-if-authorized (:organizations/slug organization-one)
+                                                 (Long/MAX_VALUE)))
           "find-one returns nil when the user does not exist"))))

--- a/test/clj/chronograph/domain/organization_test.clj
+++ b/test/clj/chronograph/domain/organization_test.clj
@@ -22,3 +22,25 @@
     (let [{user-id :users/id} (factories/create-user)
           {organization-id :organizations/id} (factories/create-organization user-id) ]
       (is (true? (acl/admin? user-id organization-id))))))
+
+(deftest find-one-organization-test
+  (testing "when users try to look up organization information"
+    (let [;; user-one and their organization
+          {user-one :users/id} (factories/create-user)
+          organization-one (factories/create-organization user-one)
+          ;; user-two and their organization
+          {user-two :users/id} (factories/create-user)
+          organization-two (factories/create-organization user-two)]
+      (is (= organization-one
+             (organization/find-one (:organizations/slug organization-one)
+                                    user-one))
+          "user-one can look up the organization they belong to")
+      (is (nil? (organization/find-one (:organizations/slug organization-two)
+                                       user-one))
+          "user-one CANNOT look up an organization they don't belong to")
+      (is (nil? (organization/find-one "this-does-not-exist"
+                                       user-one))
+          "find-one returns nil when the organization does not exist")
+      (is (nil? (organization/find-one (:organizations/slug organization-one)
+                                       (Long/MAX_VALUE)))
+          "find-one returns nil when the user does not exist"))))

--- a/test/cljs/chronograph/core_test.cljs
+++ b/test/cljs/chronograph/core_test.cljs
@@ -2,7 +2,6 @@
   (:require [cljs.test :refer-macros [deftest is testing run-tests]]
             [day8.re-frame.test :as rf-test]
             [re-frame.core :as rf]
-            [chronograph-web.events :as events]
             [chronograph-web.events.user :as user-events]
             [chronograph-web.subscriptions :as subs]))
 

--- a/test/cljs/chronograph/pages/organization/events_test.cljs
+++ b/test/cljs/chronograph/pages/organization/events_test.cljs
@@ -1,0 +1,38 @@
+(ns chronograph.pages.organization.events-test
+  (:require [cljs.test :refer-macros [deftest is testing run-tests]]
+            [day8.re-frame.test :as rf-test]
+            [re-frame.core :as rf]
+            [chronograph-web.pages.organization.events :as org-events]
+            [chronograph-web.events.routing :as routing-events]
+            [chronograph-web.subscriptions :as subs]))
+
+
+(deftest get-organization-test
+  (testing "When the organization is fetched successfully"
+    (rf-test/run-test-sync
+     (let [slug "a-test-org"
+           organization {:id 42
+                         :name "A Test Org"
+                         :slug slug
+                         :created-at "2020-09-14T14:16:06.402873Z"
+                         :updated-at "2020-09-14T14:16:06.402873Z"}]
+       (rf/reg-fx :http-xhrio
+                  (fn [_]
+                    (rf/dispatch [::org-events/fetch-organization-success
+                                  organization])))
+       (rf/dispatch [::routing-events/set-page {:slug slug :handler :organization-show}])
+       (is (= {:id 42
+               :name "A Test Org"
+               :slug "a-test-org"
+               :created-at "2020-09-14T14:16:06.402873Z"
+               :updated-at "2020-09-14T14:16:06.402873Z"}
+              @(rf/subscribe [::subs/organization slug]))))))
+
+  (testing "When the organization fetch fails"
+    (rf-test/run-test-sync
+     (let [slug "a-test-org"]
+       (rf/reg-fx :http-xhrio
+                  (fn [_]
+                    (rf/dispatch [::org-events/fetch-organization-fail])))
+       (rf/dispatch [::routing-events/set-page {:slug slug :handler :organization-show}])
+       (is (nil? @(rf/subscribe [::subs/organization slug])))))))

--- a/test/cljs/chronograph/pages/organization/events_test.cljs
+++ b/test/cljs/chronograph/pages/organization/events_test.cljs
@@ -21,6 +21,7 @@
                     (rf/dispatch [::org-events/fetch-organization-success
                                   organization])))
        (rf/dispatch [::routing-events/set-page {:slug slug :handler :organization-show}])
+       (rf/dispatch [::org-events/fetch-organization slug])
        (is (= {:id 42
                :name "A Test Org"
                :slug "a-test-org"


### PR DESCRIPTION
It's possible for a user to own more than one organization (belongs to the ACL). However, this request must return exactly the organization that matches a slug. Obviously, a user may not query details of any org they don't belong to.