### PR TITLE
[#174792610] Bugfix tasks frontend

### DIFF
--- a/src/cljc/chronograph/specs.cljc
+++ b/src/cljc/chronograph/specs.cljc
@@ -25,7 +25,11 @@
 (s/def :users/user-un (s/keys :req-un [:users/id :users/name :users/email]
                               :opt-un [:users/photo-url]))
 
-(s/def :users/google-id string?)
+(s/def :users/google-id (s/with-gen
+                          string?
+                          ;; A UUID ensures tests do not flake. A UUID is fine
+                          ;; because a google id is a uniquely random value.
+                          #(gen/fmap str (gen/uuid))))
 
 
 ;; Organizations

--- a/src/cljc/chronograph/utils/data.cljc
+++ b/src/cljc/chronograph/utils/data.cljc
@@ -1,0 +1,8 @@
+(ns chronograph.utils.data)
+
+(defn normalize-by
+  "Like group-by, except f is expected to be unique
+  for each value in the collection. Returns a map of
+  keys returned by f to the values in the collection."
+  [f coll]
+  (zipmap (map f coll) coll))

--- a/src/cljs/chronograph_web/pages/organization/events.cljs
+++ b/src/cljs/chronograph_web/pages/organization/events.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as rf]
             [chronograph-web.http :as http]
             [chronograph-web.pages.organization.db :as org-db]
-            [chronograph-web.db :as db]))
+            [chronograph-web.db :as db]
+            [chronograph.utils.data :as datautils]))
 
 (def ^:private get-organization-uri
   "/api/organizations/")
@@ -93,10 +94,10 @@
 (rf/reg-event-db
   ::fetch-tasks-success
   (fn [db [_ tasks]]
-    (update-in db
-               [:tasks]
-               merge
-               (zipmap (map :id tasks) tasks))))
+    (update db
+            :tasks
+            merge
+            (datautils/normalize-by :id tasks))))
 
 (rf/reg-event-db
   ::fetch-tasks-failure

--- a/src/cljs/chronograph_web/pages/organization/events.cljs
+++ b/src/cljs/chronograph_web/pages/organization/events.cljs
@@ -94,8 +94,10 @@
 (rf/reg-event-db
   ::fetch-tasks-success
   (fn [db [_ tasks]]
-    (assoc-in db [:tasks]
-              (zipmap (map :id tasks) tasks))))
+    (update-in db
+               [:tasks]
+               merge
+               (zipmap (map :id tasks) tasks))))
 
 (rf/reg-event-db
   ::fetch-tasks-failure

--- a/src/cljs/chronograph_web/pages/organization/subscriptions.cljs
+++ b/src/cljs/chronograph_web/pages/organization/subscriptions.cljs
@@ -24,5 +24,7 @@
                                 :as _task}]
                             (= (org-db/current-org-id db)
                                organization-id))]
-      (filter belongs-to-org?
-              (vals (get-in db [:tasks]))))))
+      (->> (get-in db [:tasks])
+           vals
+           (filter belongs-to-org?)
+           (sort-by :id)))))

--- a/src/cljs/chronograph_web/pages/organization/subscriptions.cljs
+++ b/src/cljs/chronograph_web/pages/organization/subscriptions.cljs
@@ -16,3 +16,13 @@
   ::joined-members
   (fn [db _]
     (org-db/get-joined-members db)))
+
+(rf/reg-sub
+  ::tasks
+  (fn [db [_ _]]
+    (let [belongs-to-org? (fn [{:keys [organization-id]
+                                :as _task}]
+                            (= (org-db/current-org-id db)
+                               organization-id))]
+      (filter belongs-to-org?
+              (vals (get-in db [:tasks]))))))

--- a/src/cljs/chronograph_web/pages/organization/views.cljs
+++ b/src/cljs/chronograph_web/pages/organization/views.cljs
@@ -116,5 +116,5 @@
          [:div
           [:h2 "Tasks"]
           [task-form]
-          (when-let [tasks @(rf/subscribe [::subs/tasks])]
+          (when-let [tasks @(rf/subscribe [::org-subs/tasks])]
             [task-list tasks])]]))))

--- a/src/cljs/chronograph_web/subscriptions.cljs
+++ b/src/cljs/chronograph_web/subscriptions.cljs
@@ -33,11 +33,6 @@
     (get-in db [:organizations slug])))
 
 (rf/reg-sub
-  ::tasks
-  (fn [db [_ _]]
-    (vals (get-in db [:tasks]))))
-
-(rf/reg-sub
   ::create-task-form
   (fn [db _]
     (get-in db [:create-task])))


### PR DESCRIPTION
Fixes the following:

- [When switching from one organization detail page to the other, the previous organization's tasks are flashed in the view](https://www.pivotaltracker.com/story/show/175222980)
- [The sort order of tasks changes on updating a task](https://www.pivotaltracker.com/story/show/175225930)